### PR TITLE
Convert `%NAME%` to `{{ .Name }}` to prevent blocking error on VM boot

### DIFF
--- a/lib/veewee-to-packer/builders/virtualbox.rb
+++ b/lib/veewee-to-packer/builders/virtualbox.rb
@@ -84,6 +84,7 @@ module VeeweeToPacker
               gsub("<Enter>", "<enter>").
               gsub("<Return>", "<return>").
               gsub("<Tab>", "<tab>").
+              gsub("%NAME%", "{{ .Name }}").
               gsub("%IP%", "{{ .HTTPIP }}").
               gsub("%PORT%", "{{ .HTTPPort }}")
 

--- a/lib/veewee-to-packer/builders/vmware.rb
+++ b/lib/veewee-to-packer/builders/vmware.rb
@@ -84,6 +84,7 @@ module VeeweeToPacker
               gsub("<Enter>", "<enter>").
               gsub("<Return>", "<return>").
               gsub("<Tab>", "<tab>").
+              gsub("%NAME%", "{{ .Name }}").
               gsub("%IP%", "{{ .HTTPIP }}").
               gsub("%PORT%", "{{ .HTTPPort }}")
 


### PR DESCRIPTION
My `boot_command` had this in it: `hostname=%NAME%`

That resulted in a blocking error when configuring the network.

> The name "%NAME%" is invalid.

![screen shot 2013-06-29 at 12 42 02 am](https://f.cloud.github.com/assets/353790/725525/48e8f3ae-e076-11e2-8bbd-05bb47def246.png)

d80e230 just adds substitution for `%NAME%` => `{{ .Name }}`, which resolves the issue for me.
