### PR TITLE
Add support for VM builder specific options from veewee

### DIFF
--- a/lib/veewee-to-packer.rb
+++ b/lib/veewee-to-packer.rb
@@ -106,6 +106,11 @@ module VeeweeToPacker
       warnings << ":params are not supported by Packer."
     end
 
+    if definition[:kvm]
+      definition.delete(:kvm)
+      warnings << ":kvm not supported by Packer."
+    end
+
     # Build the builders
     template["builders"] = builders.map do |builder|
       config, build_warnings = builder.convert(definition.dup, input_dir, output)

--- a/lib/veewee-to-packer/builders/virtualbox.rb
+++ b/lib/veewee-to-packer/builders/virtualbox.rb
@@ -178,6 +178,21 @@ module VeeweeToPacker
           end
         end
 
+        # Handle virtualbox specific options
+        # these are all virtualbox flags
+        if input[:virtualbox]
+          virtualbox_flags = input.delete(:virtualbox)[:vm_options]
+          unless virtualbox_flags[0].nil?
+            virtualbox_flags[0].each do |vm_flag,vm_flag_value|
+              builder["vboxmanage"] << [
+                "modifyvm", "{{.Name}}",
+                "--#{vm_flag}",
+                "#{vm_flag_value}"
+              ]
+            end
+          end
+        end
+
         # These are unused, so just ignore them.
         input.delete(:disk_format)
         input.delete(:hostiocache)
@@ -187,6 +202,7 @@ module VeeweeToPacker
         input.delete(:iso_file)
         input.delete(:ssh_host_port)
         input.delete(:ssh_key)
+        input.delete(:vmfusion)
 
         if input.length > 0
           raise Error, "Unknown keys: #{input.keys.sort.inspect}"

--- a/lib/veewee-to-packer/builders/vmware.rb
+++ b/lib/veewee-to-packer/builders/vmware.rb
@@ -161,6 +161,13 @@ module VeeweeToPacker
           builder["vmx_data"]["cpuid.coresPerSocket"] = "1"
         end
 
+        # Handle VMware Fusion specific settings
+        # Only relevant setting is enable_hypervisor_support while turns on vhv
+        if input[:vmfusion]
+          vmfusion = input.delete(:vmfusion)[:vm_options]
+          builder["vmx_data"]["vhv.enable"] = vmfusion['enable_hypervisor_support'] if vmfusion['enable_hypervisor_support']
+        end
+
         # These are unused, so just ignore them.
         input.delete(:disk_format)
         input.delete(:ioapic)
@@ -172,6 +179,7 @@ module VeeweeToPacker
         input.delete(:pae)
         input.delete(:ssh_host_port)
         input.delete(:ssh_key)
+        input.delete(:virtualbox)
 
         if input.length > 0
           raise Error, "Uknown keys: #{input.keys.sort.inspect}"


### PR DESCRIPTION
Provide handling for VM provider specific (virtualbox and vmfusion) options within veewee templates. This addresses problems with converting the ESXi veewee templates (mitchellh/veewee-to-packer#6), and ensures other templates that use virtualbox settings are processed appropriately. Behavior of these conversions was verified with current veewee trunk.

Also added a handler to ignore any KVM specific settings, in case those are added to a given template. Note that while a `:kvm` item is defined for a definition file, the veewee code does not appear to us it.

Verified proper behavior of this code against the ESXi 5.1 Veewee template, and the scientificlinux-6.1-i386 templates.
