### PR TITLE
When converting an OSX template, add the firmware (and other support) ke...

### DIFF
--- a/lib/veewee-to-packer/builders/vmware.rb
+++ b/lib/veewee-to-packer/builders/vmware.rb
@@ -200,6 +200,16 @@ module VeeweeToPacker
           builder["vmx_data"]["cpuid.coresPerSocket"] = "1"
         end
 
+        if guestos.include? "darwin"
+          builder["vmx_data"]["firmware"] = "efi"
+          builder["vmx_data"]["keyboardAndMouseProfile"] = "macProfile"
+          builder["vmx_data"]["smc.present"] = "TRUE"
+          builder["vmx_data"]["hpet0.present"] = "TRUE"
+          builder["vmx_data"]["ich7m.present"] = "TRUE"
+          builder["vmx_data"]["ehci.present"] = "TRUE"
+          builder["vmx_data"]["usb.present"] = "TRUE"
+        end
+
         # Handle VMware Fusion specific settings
         # Only relevant setting is enable_hypervisor_support while turns on vhv
         if input[:vmfusion]


### PR DESCRIPTION
When converting the base veewee OSX template for use with packer, the resulting template will not boot. It is missing the vmx settings that are required for VMWare Fusion to boot an OSX machine. Since these settings are not defined in the veewee definition.rb (settings live in veewee/lib/veewee/provider/vmfusion/box/template.vmx.erb), they are overlooked by veewee-to-packer and should be added by default for OSX images.
### Steps
#### 0. Prerequisites
- InstallESD.dmg from App Store (using 10.8.5 here).
- Packer (v0.3.9) installed and in $PATH.
- veewee-to-packer (v0.2.6) installed and in $PATH.
#### 1. Get source

``` Shell
$> git clone https://github.com/timsutton/osx-vm-templates.git
$> git clone https://github.com/jedi4ever/veewee.git
```
#### 2. Prepare OSX InstallESD.dmg image per https://github.com/timsutton/osx-vm-templates

``` Shell
$> sudo osx-vm-templates/prepare_iso/prepare_iso.sh InstallESD_10.8.5.dmg  .
```
#### 3. Convert template

``` Shell
$> veewee-to-packer veewee/templates/OSX/definition.rb 
```
#### 4. Modify new Packer template
- Remove virtualbox builder and virtualbox override settings
- Add ISO information

``` Text
"iso_checksum_type": "md5",
"iso_checksum": "...",
"iso_url": "../OSX_InstallESD_10.8.5_12F45.dmg",
```
#### 5. Validate Packer template

``` Shell
$> packer validate template.json 
Template validated successfully.
```
#### 6. Boot machine

``` Shell
$> packer build template.json 
vmware output will be in this color.

==> vmware: Downloading or copying ISO
    vmware: Downloading or copying: file:///<snip>/OSX_InstallESD_10.8.5_12F45.dmg
==> vmware: Creating virtual machine disk
==> vmware: Building and writing VMX file
==> vmware: Starting virtual machine...
==> vmware: Waiting 1m0s for boot...
```

When the machine finally comes up, the following error is given.

![](http://i.imgur.com/RokRGDK.png)
### Workaround

Using `osx-vm-templates/packer/base/template.json` as guidance, add the following setting to the vmx_data blob in the generated template. Really only the `firmware` key is needed, but the others are helpful as well.

``` Text
"firmware": "efi",
"keyboardAndMouseProfile": "macProfile",
"smc.present": "TRUE",
"hpet0.present": "TRUE",
"ich7m.present": "TRUE",
"ehci.present": "TRUE",
"usb.present": "TRUE"
```
