### PR TITLE
Correctly translate <Backspace> and display version number

### DIFF
--- a/bin/veewee-to-packer
+++ b/bin/veewee-to-packer
@@ -8,6 +8,7 @@ $stdout.sync = true
 $stderr.sync = true
 
 require 'optparse'
+require 'veewee-to-packer'
 
 # Parse arguments
 options = {
@@ -25,6 +26,11 @@ OptionParser.new do |opts|
   opts.on("-o", "--output DIR", String, "Directory where files will be outputted.") do |output|
     options[:output] = output
   end
+
+  opts.on('-v', '--version', 'Show version') do
+    puts "veewee-to-packer: #{VeeweeToPacker::VERSION}"
+    exit
+  end
 end.parse!
 
 if ARGV.length != 1
@@ -33,7 +39,6 @@ if ARGV.length != 1
 end
 
 # Do the actual conversion
-require "veewee-to-packer"
 begin
   warnings = VeeweeToPacker.convert(ARGV[0], options[:output], options[:builders])
 

--- a/lib/veewee-to-packer/builders/virtualbox.rb
+++ b/lib/veewee-to-packer/builders/virtualbox.rb
@@ -86,6 +86,7 @@ module VeeweeToPacker
               gsub("<Spacebar>", " ").
               gsub("<Tab>", "<tab>").
               gsub("<Wait>", "<wait>").
+              gsub("<Backspace>", "<bs>").
               gsub("%NAME%", "{{ .Name }}").
               gsub("%IP%", "{{ .HTTPIP }}").
               gsub("%PORT%", "{{ .HTTPPort }}")

--- a/lib/veewee-to-packer/builders/vmware.rb
+++ b/lib/veewee-to-packer/builders/vmware.rb
@@ -88,6 +88,7 @@ module VeeweeToPacker
               gsub("<Spacebar>", " ").
               gsub("<Tab>", "<tab>").
               gsub("<Wait>", "<wait>").
+              gsub("<Backspace>", "<bs>").
               gsub("%NAME%", "{{ .Name }}").
               gsub("%IP%", "{{ .HTTPIP }}").
               gsub("%PORT%", "{{ .HTTPPort }}")


### PR DESCRIPTION
A couple of minor tweaks:
- Passing the `-v` flag now causes the version number to be displayed instead of `version unknown`
- The boot command `<Backspace>` is now translated to `<bs>` which is something Packer actually uses.
