### PR TITLE
fix builder name for latest packer version

### DIFF
--- a/lib/veewee-to-packer/builders/virtualbox.rb
+++ b/lib/veewee-to-packer/builders/virtualbox.rb
@@ -71,12 +71,12 @@ module VeeweeToPacker
       }
 
       def self.name
-        "virtualbox"
+        "virtualbox-iso"
       end
 
       def self.convert(input, input_dir, output_dir)
         warnings =[]
-        builder = { "type" => "virtualbox" }
+        builder = { "type" => "virtualbox-iso" }
 
         if input[:boot_cmd_sequence]
           builder["boot_command"] = input.delete(:boot_cmd_sequence).map do |command|

--- a/lib/veewee-to-packer/builders/vmware.rb
+++ b/lib/veewee-to-packer/builders/vmware.rb
@@ -73,12 +73,12 @@ module VeeweeToPacker
       }
 
       def self.name
-        "vmware"
+        "vmware-iso"
       end
 
       def self.convert(input, input_dir, output_dir)
         warnings = []
-        builder = { "type" => "vmware" }
+        builder = { "type" => "vmware-iso" }
 
         if input[:boot_cmd_sequence]
           builder["boot_command"] = input.delete(:boot_cmd_sequence).map do |command|


### PR DESCRIPTION
React to the latest renaming of the virtualbox and vmware provider. Adapted the scripts to use "vmware-iso" and "virutalbox-iso" by default.
